### PR TITLE
Update .gitignore to latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,5 +167,8 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# Ruff stuff:
+.ruff_cache/
+
 # PyPI configuration file
 .pypirc


### PR DESCRIPTION
Incorporate the latest recommended entries into the .gitignore file to ensure that ruff cache directories are properly ignored.